### PR TITLE
Change uses of `innerHTML` to `textContent`

### DIFF
--- a/SSComments/ssc.user.js
+++ b/SSComments/ssc.user.js
@@ -15,7 +15,7 @@ var lastGivenDate;
 
 var styleEle = document.createElement('style');
 styleEle.type = 'text/css';
-styleEle.innerHTML = '.new-comment { border: 2px solid #5a5; }' +
+styleEle.textContent = '.new-comment { border: 2px solid #5a5; }' +
 '.comments-floater { position: fixed; right: 4px; top: 4px; padding: 2px 5px; width: 230px;font-size: 14px; border-radius: 5px; background: rgba(250, 250, 250, 0.90); }' +
 '.comments-scroller { word-wrap: break-word; max-height: 500px; overflow-y:scroll; }' +
 '.comments-date { font-size: 11px; }' +
@@ -74,7 +74,7 @@ divDiv.style.display = 'none';
 
 // The '[-]'
 var hider = document.createElement('span');
-hider.innerHTML = '[-]';
+hider.textContent = '[-]';
 hider.className = 'hider';
 hider.addEventListener('click', function(){
   if (commentsScroller.style.display != 'none') {
@@ -124,7 +124,7 @@ function border(since, updateTitle) {
   
   // Walk comments, setting borders as appropriate and saving new comments in a list
   for(var i = 0; i < commentList.length; ++i) {
-    var postTime = Date.parse(commentList[i].querySelector('.comment-meta a').innerHTML.replace(' at', ''));
+    var postTime = Date.parse(commentList[i].querySelector('.comment-meta a').textContent.replace(' at', ''));
     if (postTime > since) {
       commentList[i].classList.add('new-comment');
       newComments.push({time: postTime, ele: commentList[i]});
@@ -145,14 +145,14 @@ function border(since, updateTitle) {
   
   // Populate the floating comment list
   commentCountText.data = '' + newCount + ' comment' + (newCount == 1 ? '' : 's') + ' since ';
-  commentsList.innerHTML = '';
+  commentsList.textContent = '';
   if (newCount > 0 ) {
     divDiv.style.display = 'block';
     newComments.sort(function(a, b){return a.time - b.time;});
     for(i = 0; i < newCount; ++i) {
       var ele = newComments[i].ele;
       var newLi = document.createElement('li');
-      newLi.innerHTML = ele.querySelector('cite').textContent + ' <span class="comments-date">' + (new Date(newComments[i].time)).toLocaleString() + '</span>';
+      newLi.textContent = ele.querySelector('cite').textContent + ' <span class="comments-date">' + (new Date(newComments[i].time)).toLocaleString() + '</span>';
       newLi.addEventListener('click', function(ele){return function(){ele.scrollIntoView(true);};}(ele));
       commentsList.appendChild(newLi);
     }
@@ -193,8 +193,8 @@ function commentToggle() {
   var myBody = myComment.querySelector('div.comment-body');
   var myMeta = myComment.querySelector('div.comment-meta');
   var myChildren = myComment.nextElementSibling;
-  if(this.innerHTML == 'Hide') {
-    this.innerHTML = 'Show';
+  if(this.textContent == 'Hide') {
+    this.textContent = 'Show';
     myComment.style.opacity = '.6';
     myBody.style.display = 'none';
     myMeta.style.display = 'none';
@@ -203,7 +203,7 @@ function commentToggle() {
     }
   }
   else {
-    this.innerHTML = 'Hide';
+    this.textContent = 'Hide';
     myComment.style.opacity = '1';
     myBody.style.display = 'block';
     myMeta.style.display = 'block';
@@ -221,7 +221,7 @@ for(var i=0; i<comments.length; ++i) {
   var hideLink = document.createElement('a');
   hideLink.className = 'comment-reply-link';
   hideLink.style.textDecoration = 'underline';
-  hideLink.innerHTML = 'Hide';
+  hideLink.textContent = 'Hide';
 
   hideLink.addEventListener('click', commentToggle, false);
 


### PR DESCRIPTION
Since you never use the feature of [`innerHTML`](https://developer.mozilla.org/en-US/docs/Web/API/Element.innerHTML) to embed HTML, it is safer and faster to use [`textContent`](https://developer.mozilla.org/en-US/docs/Web/API/Node.textContent) instead.

You will probably have to regenerate the bookmarklet to match the source code of `ssc.user.js`, however you do that.

I did not attempt testing this change, because it would be hard to prevent my changed code from conflicting with the version of this script that the actual side loads.
