### PR TITLE
escape tildes in readme to remove strikethrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This script adds some features to the comment system at [Slate Star Codex](http://slatestarcodex.com/). In particular:
 
-- New comments are highlighted and given the searchable text "~new~" so that you can C-f through them in the order they appear on the page.
+- New comments are highlighted and given the searchable text "\~new\~" so that you can C-f through them in the order they appear on the page.
 - An expandable box appears in the upper-right, which allows you to set the time after which comments are highlighted and gives you a list of new comments. Clicking an entries in the list will bring you to that entry.
 - A button to hide a comment and its subthread, appearing at the bottom of every comment.
 - For nested comments, a link to their parent.


### PR DESCRIPTION
"~new~" produces a struckthrough "new", "\~new\~" produces "~new~". Markdown!